### PR TITLE
Added experimental capability to search through TICA FFIs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,6 +175,7 @@ Please include a self-contained example that fully demonstrates your problem or 
 Changelog:
 ==========
 
+  - Added ability to use "TICA" FFIs. This is experimental and might be buggy.
   - Patch removes the un-needed `fitsio` dependency
   - Initial v1.0.0 release of `tesscube`.
   

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tesscube"
-version = "1.0.5"
+version = "1.1.0"
 description = ""
 authors = ["TESS Science Support Center <tesshelp@bigbang.gsfc.nasa.gov>", "Christina Hedges <christina.l.hedges@nasa.gov>"]
 license = "MIT"

--- a/src/tesscube/__init__.py
+++ b/src/tesscube/__init__.py
@@ -1,9 +1,20 @@
-__version__ = "1.0.5"
 # Standard library
 import os  # noqa
 import tempfile
 
 PACKAGEDIR = os.path.abspath(os.path.dirname(__file__))
+
+from importlib.metadata import version, PackageNotFoundError  # noqa
+
+
+def get_version():
+    try:
+        return version("tesscube")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+__version__ = get_version()
 
 HDR_SIZE = 2880  # bytes
 BYTES_PER_PIX = 4  # float32

--- a/src/tesscube/wcs.py
+++ b/src/tesscube/wcs.py
@@ -56,8 +56,12 @@ def _extract_average_WCS(hdu):
                 value = data[idx]
                 idx += 1
             wcs_hdu.header[attr] = value
-    wcs_hdu.header["WCSAXES"] = int(wcs_hdu.header["WCSAXES"])
-    wcs_hdu.header["WCSAXESP"] = int(wcs_hdu.header["WCSAXESP"])
+    wcs_hdu.header["WCSAXES"] = int(
+        wcs_hdu.header["WCSAXES"] if "WCSAXES" in wcs_hdu.header.keys() else 2
+    )
+    wcs_hdu.header["WCSAXESP"] = int(
+        wcs_hdu.header["WCSAXESP"] if "WCSAXESP" in wcs_hdu.header.keys() else 2
+    )
     return WCS(wcs_hdu.header)
 
 


### PR DESCRIPTION
TICA FFIs are a slightly different format to SPOC FFIs, and don't contain all of the same information (including errors).

This PR adds the ability to search through TICA FFIs instead of SPOC (which is still the default). This should enable us to search new data quickly, if needed. 
